### PR TITLE
Support appending log paths for pre-defined software

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ script:
 
   # Check if Pimp my Log is reachable.
   - curl http://127.0.0.1/pimpmylog/
+
+  # Debug
+  - ls -l /var/www/pimpmylog/cfg/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The version of Pimp my Log to install. Can be any valid tag, branch, or `HEAD`.
 
 The setup of Pimp my Log allows for auto-configuration if the installation directory has `777` privileges, but this is an insecure way to install Pimp my Log. If you're installing on a local development environment, this is relatively harmless to set to `yes` to ease in installation... but if you're running this on a production or publicly-available server, don't even _think_ about changing this value!
 
+    pimpmylog_extra_paths:
+      - software: apache
+        access_files:
+          - other_vhosts_access.log
+          - other_vhosts_access_log
+        error_files: []
+        directories: []
+
+Add additional log files to an existing `software` (out of the box PimpMyLog supports `apache`, `nginx`, `iis` and `php`). Specify the filenames of the additional log files in `access_files` or `error_files` (optional), alternatively specify an additional `directory` where PimpMyLog should look for the log files.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,11 @@ pimpmylog_install_dir: /var/www/pimpmylog
 pimpmylog_repo: https://github.com/potsky/PimpMyLog.git
 pimpmylog_version: master
 pimpmylog_grant_all_privs: no
+
+pimpmylog_extra_paths:
+  - software: apache
+    access_files:
+      - other_vhosts_access.log
+      - other_vhosts_access_log
+    error_files: []
+    directories: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,13 @@
     state: directory
     mode: 0777
   when: pimpmylog_grant_all_privs
+
+- name: Copy custom paths configs in place.
+  template:
+    src: custom.paths.user.php.j2
+    dest: "{{ pimpmylog_install_dir }}/cfg/{{ item.software }}.paths.user.php"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: pimpmylog_extra_paths
+  when: pimpmylog_extra_paths | length

--- a/templates/custom.paths.user.php.j2
+++ b/templates/custom.paths.user.php.j2
@@ -1,0 +1,20 @@
+<?php
+
+include_once __DIR__ . '/{{ item.software }}.paths.php';
+
+{% if item.directories is defined %}
+{% for path in item.directories %}
+$paths[] = '{{ path }}';
+{% endfor %}
+{% endif %}
+
+{% if item.access_files is defined %}
+{% for file in item.access_files %}
+$files['access'][] = '{{ file }}';
+{% endfor %}
+{% endif %}
+{% if item.error_files is defined %}
+{% for file in item.error_files %}
+$files['error'][] = '{{ file }}';
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
So I looked into what it would take to configure PimpMyLog properly out of the box. To be honest it looks horrible trying to do it for all different distro. We basically need to add a variable for every log path for every distro and then duplicate the nasty [config files](https://github.com/potsky/PimpMyLog/blob/943e7123a127e099de3cd5b37e611ad9ac6901ee/cfg/nginx.config.php). Also mysql vs mariadb. I vote for not bootstrapping pimpmylog but letting users customise defaults a bit.

This is the first PR which supports adding new filenames and locations for _all_ log files which belong to a supported software. This also adds the quite common `other_vhosts_access.log` file.

Later we could add support for extra software by
1. creating a [`softwares.inc.user.php` file](https://github.com/potsky/PimpMyLog/blob/master/cfg/softwares.inc.php#L29:L58)
2. creating a few default non-configurable softwares. Could probably begin with MySQL as there's an [example config](http://support.pimpmylog.com/kb/softwares/mysql) for this already.

This PR is **NOT** tested properly yet. I'll test it later today but I wanted to get your initial thought on this approach before I invest more time in it.
